### PR TITLE
Strip ChapNumbercn paras out of HTML

### DIFF
--- a/wordtohtml.xsl
+++ b/wordtohtml.xsl
@@ -202,7 +202,8 @@
       select="'PageBreakpb',
               'SectionBreaksbr',
               'PartStartpts',
-              'PartEndpte'"/>
+              'PartEndpte',
+              'ChapNumbercn'"/>
   </xsl:variable>
 
   <!-- Paragraph styles used to add spacing, to be ignored when 
@@ -224,7 +225,6 @@
   <xsl:variable name="top-level-body-breaks" as="xs:string*">
     <xsl:sequence
       select="'BMHeadbmh',
-              'ChapNumbercn',
               'ChapTitlect',
               'PartNumberpn',
               'PartTitlept',
@@ -274,7 +274,6 @@
       select="'BMHeadbmh',
               'PartNumberpn',
               'PartTitlept',
-              'ChapNumbercn',
               'ChapTitlect',
               'FMHeadfmh',
               'TitlepageBookTitletit',
@@ -378,8 +377,7 @@
                 <xsl:value-of select="'part'"/>
               </xsl:when>
               <xsl:when
-                test="$word-style = 'ChapNumbercn' or
-                      $word-style = 'ChapTitlect'">
+                test="$word-style = 'ChapTitlect'">
                 <xsl:value-of select="'chapter'"/>
               </xsl:when>
               <xsl:when

--- a/wordtohtml.xsl
+++ b/wordtohtml.xsl
@@ -443,8 +443,8 @@
       <xsl:if
       test="preceding-sibling::w:p
             [w:pPr/w:pStyle/@w:val = 'ChapNumbercn']">
-      <xsl:attribute name="class">
-        <xsl:value-of select="'numbered'"/>
+      <xsl:attribute name="data-labels">
+        <xsl:value-of select="'yes'"/>
       </xsl:attribute>
     </xsl:if>
       <xsl:apply-templates select="w:pPr/w:pStyle/@w:val"/>

--- a/wordtohtml.xsl
+++ b/wordtohtml.xsl
@@ -440,6 +440,13 @@
   <xsl:template
     match="w:p[w:pPr/w:pStyle/@w:val = $top-level-heads]">
     <h1>
+      <xsl:if
+      test="preceding-sibling::w:p
+            [w:pPr/w:pStyle/@w:val = 'ChapNumbercn']">
+      <xsl:attribute name="class">
+        <xsl:value-of select="'numbered'"/>
+      </xsl:attribute>
+    </xsl:if>
       <xsl:apply-templates select="w:pPr/w:pStyle/@w:val"/>
       <xsl:apply-templates select="w:r"/>
     </h1>

--- a/wordtohtml.xsl
+++ b/wordtohtml.xsl
@@ -443,7 +443,7 @@
       <xsl:if
       test="preceding::w:p
             [w:pPr/w:pStyle/@w:val = 'ChapNumbercn']
-            and $word-style = 'ChapTitlect'">
+            and ./w:pPr/w:pStyle/@w:val = 'ChapTitlect'">
       <xsl:attribute name="data-autolabel">
         <xsl:value-of select="'yes'"/>
       </xsl:attribute>

--- a/wordtohtml.xsl
+++ b/wordtohtml.xsl
@@ -441,9 +441,10 @@
     match="w:p[w:pPr/w:pStyle/@w:val = $top-level-heads]">
     <h1>
       <xsl:if
-      test="preceding-sibling::w:p
-            [w:pPr/w:pStyle/@w:val = 'ChapNumbercn']">
-      <xsl:attribute name="data-labels">
+      test="preceding::w:p
+            [w:pPr/w:pStyle/@w:val = 'ChapNumbercn']
+            and $word-style = 'ChapTitlect'">
+      <xsl:attribute name="data-autolabel">
         <xsl:value-of select="'yes'"/>
       </xsl:attribute>
     </xsl:if>


### PR DESCRIPTION
These code changes strip out any paragraphs tagged as ChapNumbercn. 

ChapNumbercn paragraphs will only exist in combination with ChapTitlect paragraphs, in manuscripts where both a printed chapter number and chapter title are required. In cases where only a chapter number or chapter title is required, the ChapTitlect style will always be used. 

The code has been revised to remove the physical ChapNumbercn paragraph, replacing it with a switch to add auto-labels to chapter titles (data-autolabel=yes). ChapNumbercn has been removed from the list of top-level-breaks and from the generated toc.

Fixes #10 (mostly) and affects https://github.com/macmillanpublishers/bookmaker_epubmaker/issues/6